### PR TITLE
Add missing <cstdint> include

### DIFF
--- a/src/ck3_world/titles/title.hpp
+++ b/src/ck3_world/titles/title.hpp
@@ -1,6 +1,7 @@
 #ifndef CK3_TITLE_H
 #define CK3_TITLE_H
 
+#include <cstdint>
 #include <optional>
 #include <set>
 #include <string>


### PR DESCRIPTION
std::uint8_t is already being used without a manual inclusion of <cstdint>, which prevents compilation on my Arch Linux with GCC 16.